### PR TITLE
Fix cleanup with stopped tasks

### DIFF
--- a/tests/tasks/test_task.py
+++ b/tests/tasks/test_task.py
@@ -372,6 +372,7 @@ class TestTasks:
         decision_fixture.next_dags = []
         decision_fixture.root_dag = None
         dagger.service.services.Dagger.app._update_instance = CoroutineMock()
+        template_fixture.on_complete = CoroutineMock()
         await template_fixture.stop()
         assert template_fixture.status == TaskStatus(
             code=TaskStatusEnum.STOPPED.name, value=TaskStatusEnum.STOPPED.value
@@ -394,6 +395,7 @@ class TestTasks:
         assert not decision_fixture.stop.called
         assert sensor_fixture.stop.called
         assert dagger.service.services.Dagger.app._update_instance.called
+        assert template_fixture.on_complete.called
 
     @pytest.mark.asyncio
     async def test_get_remaining_tasks(


### PR DESCRIPTION
moving the stop implementation to base class and implementing clean up by invoking `on_complete` on the workflow
## Description

## Type of Change

- [x ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/dagger/blob/main/CONTRIBUTING.md)
- [x ] Existing issues have been referenced (where applicable)
- [ x] I have verified this change is not present in other open pull requests
- [ x] Functionality is documented
- [ x] All code style checks pass
- [ x] New code contribution is covered by automated tests
- [ x] All new and existing tests pass
